### PR TITLE
Improve wasm runtime performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const encodeString = (name, instance) => {
 
 const createFnmatch = async () => {
   const go = new Go();
-  const instance = wasm(go.importObject)
+  const { instance } = await wasm(go.importObject)
 
   go.run(instance); 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashid/fnmatch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Wasm wrapper for @slashid/fnmatch go library",
   "type": "module",
   "main": "dist/index.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ export default {
     format: 'es'
   },
   plugins: [wasm({
-    sync: ['main.wasm']
+    // sync: ['main.wasm']
+    targetEnv: "auto-inline"
   })]
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,6 @@ export default {
     format: 'es'
   },
   plugins: [wasm({
-    // sync: ['main.wasm']
     targetEnv: "auto-inline"
   })]
 };


### PR DESCRIPTION
This changes the rollup config to implement [the recommended wasm loading optimisations](https://web.dev/articles/loading-wasm), this is necessary to avoid the following error in some environments:

> WebAssembly.Compile is disallowed on the main thread, if the buffer size is larger than 4KB.

### Changes
- Remove `sync`
    - Previously this was being used because it inlined the wasm module, which made this lib more portable
    - By default `@rollup/plugin-wasm` async loads modules, but enabling `sync` disables that. Removing `sync` makes the module loading async again.
- Change `targetEnv` to force inline instead, keeping the lib portability

Once this PR is merged I'll publish `@slashid/fnmatch@0.2.0`